### PR TITLE
ci: Cypress E2E pipeline — headless, triggered on PR to main

### DIFF
--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -1,0 +1,74 @@
+name: Cypress — E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  cypress:
+    name: Cypress Headless
+    runs-on: ubuntu-latest
+
+    env:
+      PORT: 3000
+      NODE_ENV: test
+      BASE_URL: http://localhost:3000
+      MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRES_IN: 24h
+      JWT_REFRESH_SECRET: ${{ secrets.JWT_REFRESH_SECRET }}
+      JWT_REFRESH_EXPIRES_IN: 7d
+      UPLOAD_MAX_SIZE_MB: 5
+
+    steps:
+      # ── 1. Clonar repositório ────────────────────────────────────────────────
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ── 2. Container Node 20 ─────────────────────────────────────────────────
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # ── 3. Instalar dependências ─────────────────────────────────────────────
+      - name: Install dependencies
+        run: npm ci
+
+      # ── 4. Iniciar aplicação em background ───────────────────────────────────
+      - name: Start server in background
+        run: node server.js &
+
+      # ── 5. Aguardar servidor estar no ar ─────────────────────────────────────
+      - name: Wait for server to be ready
+        run: |
+          echo "Aguardando http://localhost:3000/health ..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/health > /dev/null; then
+              echo "✅ Servidor disponível após ${i} tentativa(s)."
+              break
+            fi
+            echo "  tentativa $i/30 — aguardando 2s..."
+            sleep 2
+          done
+          curl -sf http://localhost:3000/health \
+            || (echo "❌ Servidor não respondeu a tempo." && exit 1)
+
+      # ── 6. Rodar testes Cypress em headless mode ─────────────────────────────
+      - name: Run Cypress tests (headless)
+        run: npx cypress run --headless --browser electron
+
+      # ── 7. Publicar artefatos em caso de falha ───────────────────────────────
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: reports/cypress/screenshots
+          if-no-files-found: ignore
+
+      # ── 8. Finalizar ─────────────────────────────────────────────────────────
+      - name: Stop server
+        if: always()
+        run: pkill -f "node server.js" || true

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,19 @@
+const { defineConfig } = require('cypress');
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    specPattern: 'tests/**/*.cy.js',
+    supportFile: 'cypress/support/e2e.js',
+    fixturesFolder: 'tests/fixtures',
+    screenshotsFolder: 'reports/cypress/screenshots',
+    videosFolder: 'reports/cypress/videos',
+    video: false,
+    env: {
+      BASE_URL: 'http://localhost:3000',
+    },
+    setupNodeEvents(on, config) {
+      return config;
+    },
+  },
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,88 @@
+const BASE = '/api/v1';
+
+Cypress.Commands.add('register', (userData) => {
+  return cy.request({
+    method: 'POST',
+    url: `${BASE}/users/register`,
+    body: userData,
+    failOnStatusCode: false,
+  });
+});
+
+Cypress.Commands.add('login', (credentials) => {
+  return cy.request({
+    method: 'POST',
+    url: `${BASE}/auth/login`,
+    body: credentials,
+    failOnStatusCode: false,
+  }).then((res) => {
+    if (res.status === 200) {
+      Cypress.env('accessToken', res.body.accessToken);
+      Cypress.env('refreshToken', res.body.refreshToken);
+      Cypress.env('userId', res.body.user._id);
+    }
+    return res;
+  });
+});
+
+Cypress.Commands.add('registerAndLogin', (overrides = {}) => {
+  const ts = Date.now();
+  const userData = {
+    name: 'Cypress User',
+    email: `cy_${ts}@jobapp.test`,
+    password: 'CypressPass1',
+    ...overrides,
+  };
+  return cy.register(userData).then(() => {
+    return cy.login({ email: userData.email, password: userData.password }).then((res) => {
+      return {
+        token: res.body.accessToken,
+        refreshToken: res.body.refreshToken,
+        userId: res.body.user._id,
+        credentials: { email: userData.email, password: userData.password },
+      };
+    });
+  });
+});
+
+Cypress.Commands.add('api', (method, url, body = null, tokenOverride = null) => {
+  const token = tokenOverride || Cypress.env('accessToken');
+  const options = {
+    method,
+    url,
+    failOnStatusCode: false,
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  };
+  if (body) options.body = body;
+  return cy.request(options);
+});
+
+Cypress.Commands.add('createJobApplication', (payload) => {
+  const defaults = {
+    company: `Cypress Corp ${Date.now()}`,
+    position: 'QA Engineer',
+    applicationDate: new Date().toISOString().split('T')[0],
+  };
+  return cy.api('POST', `${BASE}/job-applications`, { ...defaults, ...payload });
+});
+
+Cypress.Commands.add('addStage', (appId, stagePayload) => {
+  return cy.api('POST', `${BASE}/job-applications/${appId}/stages`, stagePayload);
+});
+
+Cypress.Commands.add('createLinkedinCompany', (payload) => {
+  const defaults = {
+    name: `Cypress Company ${Date.now()}`,
+    linkedinUrl: `https://www.linkedin.com/company/cy-test-${Date.now()}`,
+  };
+  return cy.api('POST', `${BASE}/linkedin/companies`, { ...defaults, ...payload });
+});
+
+Cypress.Commands.add('createLinkedinContact', (payload) => {
+  const defaults = {
+    name: `Cypress Contact ${Date.now()}`,
+    linkedinUrl: `https://www.linkedin.com/in/cy-contact-${Date.now()}`,
+    type: 'Recrutador',
+  };
+  return cy.api('POST', `${BASE}/linkedin/contacts`, { ...defaults, ...payload });
+});

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,0 +1,3 @@
+import './commands';
+
+Cypress.on('uncaught:exception', () => false);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "db:setup": "node src/scripts/setupDB.js",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "cy:run": "cypress run",
+    "cy:open": "cypress open",
+    "cy:run:headless": "cypress run --headless --browser electron"
   },
   "keywords": [
     "job",
@@ -35,6 +38,7 @@
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
+    "cypress": "^13.17.0",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.1.4",
     "nodemon": "^3.1.3",

--- a/tests/auth/auth.cy.js
+++ b/tests/auth/auth.cy.js
@@ -1,0 +1,131 @@
+const BASE = '/api/v1';
+
+describe('[AUTH] Authentication Layer — Cypress', () => {
+  let registeredCredentials;
+
+  before(() => {
+    cy.registerAndLogin().then(({ credentials }) => {
+      registeredCredentials = credentials;
+    });
+  });
+
+  describe('POST /api/v1/auth/login', () => {
+    it('US02-CY-001 | should return 200 with accessToken and refreshToken', () => {
+      cy.login(registeredCredentials).then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body).to.have.property('accessToken').that.is.a('string');
+        expect(res.body).to.have.property('refreshToken').that.is.a('string');
+        expect(res.body.user).to.not.have.property('password');
+      });
+    });
+
+    it('US02-CY-002 | should return 401 for wrong password', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        body: { email: registeredCredentials.email, password: 'WRONG_PASS_99' },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body.message).to.equal('Credenciais inválidas');
+      });
+    });
+
+    it('US02-CY-003 | should return 401 for non-existent email', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        body: { email: `ghost_${Date.now()}@nowhere.test`, password: 'AnyPass1234' },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body.message).to.equal('Credenciais inválidas');
+      });
+    });
+
+    it('US02-CY-004 | should return 400 for missing email', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        body: { password: 'TestPass123' },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body.errors).to.be.an('array').and.have.length.greaterThan(0);
+      });
+    });
+
+    it('US02-CY-005 | should return 400 for missing password', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/login`,
+        body: { email: registeredCredentials.email },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body.errors).to.be.an('array');
+      });
+    });
+  });
+
+  describe('POST /api/v1/auth/refresh', () => {
+    it('US02-CY-006 | should return 200 with new tokens for valid refresh token', () => {
+      cy.registerAndLogin().then(({ refreshToken }) => {
+        cy.request({
+          method: 'POST',
+          url: `${BASE}/auth/refresh`,
+          body: { refreshToken },
+          failOnStatusCode: false,
+        }).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.have.property('accessToken');
+          expect(res.body).to.have.property('refreshToken');
+        });
+      });
+    });
+
+    it('US02-CY-007 | should return 401 for invalid refresh token', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/refresh`,
+        body: { refreshToken: 'invalid.token.abc' },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+
+    it('US02-CY-008 | should return 400 when refreshToken is absent', () => {
+      cy.request({
+        method: 'POST',
+        url: `${BASE}/auth/refresh`,
+        body: {},
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(400);
+      });
+    });
+  });
+
+  describe('JWT Guard — Protected Routes', () => {
+    it('US02-CY-009 | should return 401 when Authorization header is missing', () => {
+      cy.request({
+        method: 'GET',
+        url: `${BASE}/users/me`,
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body.message).to.equal('Token de autenticação não fornecido');
+      });
+    });
+
+    it('US02-CY-010 | should return 200 for valid Bearer token on protected route', () => {
+      cy.registerAndLogin().then(({ token }) => {
+        cy.api('GET', `${BASE}/users/me`, null, token).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.user).to.include.keys('_id', 'email');
+        });
+      });
+    });
+  });
+});

--- a/tests/fixtures/auth.json
+++ b/tests/fixtures/auth.json
@@ -1,0 +1,20 @@
+{
+  "validLogin": {
+    "email": "fixture_user@jobapp.test",
+    "password": "Fixture1234"
+  },
+  "invalidPassword": {
+    "email": "fixture_user@jobapp.test",
+    "password": "wrongpassword"
+  },
+  "nonExistentUser": {
+    "email": "ghost_user@jobapp.test",
+    "password": "AnyPass1234"
+  },
+  "missingPassword": {
+    "email": "fixture_user@jobapp.test"
+  },
+  "missingEmail": {
+    "password": "Fixture1234"
+  }
+}

--- a/tests/fixtures/jobApplications.json
+++ b/tests/fixtures/jobApplications.json
@@ -1,0 +1,45 @@
+{
+  "valid": {
+    "company": "Nubank",
+    "position": "Backend Engineer",
+    "description": "Node.js API development for financial services",
+    "salary": 15000,
+    "benefits": ["VR", "VT", "Plano de Saúde", "Stock Options"],
+    "applicationDate": "2026-05-01"
+  },
+  "minimal": {
+    "company": "Itaú",
+    "position": "Software Engineer",
+    "applicationDate": "2026-05-02"
+  },
+  "missingCompany": {
+    "position": "Developer",
+    "applicationDate": "2026-05-01"
+  },
+  "negativeSalary": {
+    "company": "BadCorp",
+    "position": "Dev",
+    "applicationDate": "2026-05-01",
+    "salary": -1000
+  },
+  "updatePayload": {
+    "salary": 18000,
+    "description": "Updated description after interview"
+  },
+  "stages": {
+    "feedback": {
+      "status": "Feedback",
+      "date": "2026-05-05",
+      "notes": "Retorno positivo do RH"
+    },
+    "interview": {
+      "status": "Entrevista",
+      "date": "2026-05-10",
+      "notes": "Entrevista com o gerente de engenharia"
+    },
+    "invalidStatus": {
+      "status": "Reprovado",
+      "date": "2026-05-10"
+    }
+  }
+}

--- a/tests/fixtures/linkedin.json
+++ b/tests/fixtures/linkedin.json
@@ -1,0 +1,35 @@
+{
+  "validCompany": {
+    "name": "Nubank",
+    "linkedinUrl": "https://www.linkedin.com/company/nubank",
+    "sector": "Fintech",
+    "size": "1000-5000",
+    "website": "https://nubank.com.br"
+  },
+  "invalidCompanyUrl": {
+    "name": "Bad URL Corp",
+    "linkedinUrl": "https://www.instagram.com/badcorp"
+  },
+  "validRecruiter": {
+    "name": "Ana Recrutadora",
+    "linkedinUrl": "https://www.linkedin.com/in/ana-recrutadora",
+    "type": "Recrutador",
+    "title": "Senior Technical Recruiter"
+  },
+  "validCollaborator": {
+    "name": "Carlos Dev",
+    "linkedinUrl": "https://www.linkedin.com/in/carlos-dev",
+    "type": "Colaborador",
+    "title": "Senior Software Engineer"
+  },
+  "invalidContactUrl": {
+    "name": "Bad URL Contact",
+    "linkedinUrl": "https://www.instagram.com/badcontact",
+    "type": "Recrutador"
+  },
+  "invalidContactType": {
+    "name": "Wrong Type",
+    "linkedinUrl": "https://www.linkedin.com/in/wrongtype",
+    "type": "Manager"
+  }
+}

--- a/tests/fixtures/users.json
+++ b/tests/fixtures/users.json
@@ -1,0 +1,30 @@
+{
+  "validUser": {
+    "name": "Eddie Lustosa",
+    "email": "eddie@jobapp.test",
+    "password": "Eddie1234"
+  },
+  "weakPassword": {
+    "name": "Weak User",
+    "email": "weak@jobapp.test",
+    "password": "abc"
+  },
+  "noNumberPassword": {
+    "name": "No Number",
+    "email": "nonumber@jobapp.test",
+    "password": "abcdefghij"
+  },
+  "invalidEmail": {
+    "name": "Bad Email",
+    "email": "not-an-email",
+    "password": "ValidPass1"
+  },
+  "missingName": {
+    "email": "noname@jobapp.test",
+    "password": "ValidPass1"
+  },
+  "missingEmail": {
+    "name": "No Email User",
+    "password": "ValidPass1"
+  }
+}

--- a/tests/jobapplications/jobApplications.cy.js
+++ b/tests/jobapplications/jobApplications.cy.js
@@ -1,0 +1,176 @@
+const BASE = '/api/v1/job-applications';
+
+describe('[JOB APPLICATIONS] Job Applications Layer — Cypress', () => {
+  let token, userId, otherToken;
+
+  beforeEach(() => {
+    cy.registerAndLogin().then((auth) => {
+      token = auth.token;
+      userId = auth.userId;
+    });
+    cy.registerAndLogin().then((auth) => {
+      otherToken = auth.token;
+    });
+  });
+
+  describe('POST /api/v1/job-applications', () => {
+    it('US03-CY-001 | should return 201 with status=Enviado and userId assigned', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body.status).to.equal('Enviado');
+          expect(res.body.userId).to.equal(userId);
+          expect(res.body).to.include.keys('_id', 'company', 'position');
+        });
+      });
+    });
+
+    it('US03-CY-002 | should return 201 with minimal required payload', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.minimal, token).then((res) => {
+          expect(res.status).to.equal(201);
+        });
+      });
+    });
+
+    it('US03-CY-003 | should return 400 when company is missing', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.missingCompany, token).then((res) => {
+          expect(res.status).to.equal(400);
+          const fields = res.body.errors.map((e) => e.field);
+          expect(fields).to.include('company');
+        });
+      });
+    });
+
+    it('US03-CY-004 | should return 400 for negative salary', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.negativeSalary, token).then((res) => {
+          expect(res.status).to.equal(400);
+        });
+      });
+    });
+
+    it('US03-CY-005 | should return 401 without auth token', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.request({
+          method: 'POST',
+          url: BASE,
+          body: f.valid,
+          failOnStatusCode: false,
+        }).then((res) => {
+          expect(res.status).to.equal(401);
+        });
+      });
+    });
+  });
+
+  describe('GET /api/v1/job-applications', () => {
+    it('US03-CY-006 | should return only this user\'s applications', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token);
+        cy.api('POST', BASE, f.minimal, token);
+        cy.api('POST', BASE, f.valid, otherToken);
+
+        cy.api('GET', BASE, null, token).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body).to.be.an('array').with.lengthOf(2);
+          res.body.forEach((app) => expect(app.userId).to.equal(userId));
+        });
+      });
+    });
+  });
+
+  describe('GET /api/v1/job-applications/:id', () => {
+    it('US03-CY-007 | should return 200 with full application details', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          cy.api('GET', `${BASE}/${created.body._id}`, null, token).then((res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body._id).to.equal(created.body._id);
+          });
+        });
+      });
+    });
+
+    it('US03-CY-008 | should return 403 when accessing another user\'s application', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, otherToken).then((created) => {
+          cy.api('GET', `${BASE}/${created.body._id}`, null, token).then((res) => {
+            expect(res.status).to.equal(403);
+          });
+        });
+      });
+    });
+  });
+
+  describe('PUT /api/v1/job-applications/:id', () => {
+    it('US03-CY-009 | should return 200 with updated fields', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          cy.api('PUT', `${BASE}/${created.body._id}`, f.updatePayload, token).then((res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body.salary).to.equal(f.updatePayload.salary);
+          });
+        });
+      });
+    });
+  });
+
+  describe('DELETE /api/v1/job-applications/:id', () => {
+    it('US03-CY-010 | should return 204 and 404 on subsequent GET', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          const id = created.body._id;
+          cy.api('DELETE', `${BASE}/${id}`, null, token).then((del) => {
+            expect(del.status).to.equal(204);
+          });
+          cy.api('GET', `${BASE}/${id}`, null, token).then((get) => {
+            expect(get.status).to.equal(404);
+          });
+        });
+      });
+    });
+  });
+
+  describe('POST /api/v1/job-applications/:id/stages', () => {
+    it('US05-CY-001 | should return 201 and update application status', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          const id = created.body._id;
+          cy.api('POST', `${BASE}/${id}/stages`, f.stages.feedback, token).then((res) => {
+            expect(res.status).to.equal(201);
+            expect(res.body.status).to.equal('Feedback');
+          });
+        });
+      });
+    });
+
+    it('US05-CY-002 | should return 400 for invalid stage status', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          cy.api('POST', `${BASE}/${created.body._id}/stages`, f.stages.invalidStatus, token).then((res) => {
+            expect(res.status).to.equal(400);
+          });
+        });
+      });
+    });
+  });
+
+  describe('GET /api/v1/job-applications/:id/stages', () => {
+    it('US05-CY-003 | should return stages in chronological order', () => {
+      cy.fixture('jobApplications').then((f) => {
+        cy.api('POST', BASE, f.valid, token).then((created) => {
+          const id = created.body._id;
+          cy.api('POST', `${BASE}/${id}/stages`, f.stages.feedback, token);
+          cy.api('POST', `${BASE}/${id}/stages`, f.stages.interview, token);
+
+          cy.api('GET', `${BASE}/${id}/stages`, null, token).then((res) => {
+            expect(res.status).to.equal(200);
+            expect(res.body).to.be.an('array').with.lengthOf(2);
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/linkedin/linkedin.cy.js
+++ b/tests/linkedin/linkedin.cy.js
@@ -1,0 +1,185 @@
+const COMPANIES = '/api/v1/linkedin/companies';
+const CONTACTS = '/api/v1/linkedin/contacts';
+
+const uniqueCompanyUrl = () =>
+  `https://www.linkedin.com/company/cy-co-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+const uniqueContactUrl = () =>
+  `https://www.linkedin.com/in/cy-ct-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+describe('[LINKEDIN] LinkedIn Layer — Cypress', () => {
+  let token, otherToken;
+
+  beforeEach(() => {
+    cy.registerAndLogin().then((auth) => { token = auth.token; });
+    cy.registerAndLogin().then((auth) => { otherToken = auth.token; });
+  });
+
+  describe('POST /api/v1/linkedin/companies', () => {
+    it('US06-CY-001 | should return 201 and persist LinkedIn company profile', () => {
+      cy.fixture('linkedin').then((f) => {
+        const payload = { ...f.validCompany, linkedinUrl: uniqueCompanyUrl() };
+        cy.api('POST', COMPANIES, payload, token).then((res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body).to.include.keys('_id', 'name', 'linkedinUrl');
+        });
+      });
+    });
+
+    it('US06-CY-002 | should return 409 for duplicate URL by same user', () => {
+      const url = uniqueCompanyUrl();
+      cy.api('POST', COMPANIES, { name: 'Corp A', linkedinUrl: url }, token);
+      cy.api('POST', COMPANIES, { name: 'Corp A2', linkedinUrl: url }, token).then((res) => {
+        expect(res.status).to.equal(409);
+        expect(res.body.message).to.equal('Empresa já cadastrada');
+      });
+    });
+
+    it('US06-CY-003 | should allow same URL for different users', () => {
+      const url = uniqueCompanyUrl();
+      cy.api('POST', COMPANIES, { name: 'Corp', linkedinUrl: url }, token).then((r1) => {
+        expect(r1.status).to.equal(201);
+      });
+      cy.api('POST', COMPANIES, { name: 'Corp', linkedinUrl: url }, otherToken).then((r2) => {
+        expect(r2.status).to.equal(201);
+      });
+    });
+
+    it('US06-CY-004 | should return 400 for URL not matching linkedin.com/company/ pattern', () => {
+      cy.fixture('linkedin').then((f) => {
+        cy.api('POST', COMPANIES, f.invalidCompanyUrl, token).then((res) => {
+          expect(res.status).to.equal(400);
+        });
+      });
+    });
+
+    it('US06-CY-005 | should return 401 without authentication token', () => {
+      cy.request({
+        method: 'POST',
+        url: COMPANIES,
+        body: { name: 'Test', linkedinUrl: uniqueCompanyUrl() },
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+  });
+
+  describe('GET /api/v1/linkedin/companies', () => {
+    it('US06-CY-006 | should return only the authenticated user\'s companies', () => {
+      cy.api('POST', COMPANIES, { name: 'A', linkedinUrl: uniqueCompanyUrl() }, token);
+      cy.api('POST', COMPANIES, { name: 'B', linkedinUrl: uniqueCompanyUrl() }, token);
+      cy.api('POST', COMPANIES, { name: 'C', linkedinUrl: uniqueCompanyUrl() }, otherToken);
+
+      cy.api('GET', COMPANIES, null, token).then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+      });
+    });
+  });
+
+  describe('PUT | DELETE /api/v1/linkedin/companies/:id', () => {
+    it('US06-CY-007 | should return 200 and updated fields for PUT', () => {
+      cy.api('POST', COMPANIES, { name: 'Updatable', linkedinUrl: uniqueCompanyUrl() }, token).then((created) => {
+        cy.api('PUT', `${COMPANIES}/${created.body._id}`, { sector: 'Fintech', notes: 'Top company' }, token).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.sector).to.equal('Fintech');
+        });
+      });
+    });
+
+    it('US06-CY-008 | should return 204 for DELETE and 404 on subsequent GET', () => {
+      cy.api('POST', COMPANIES, { name: 'To Delete', linkedinUrl: uniqueCompanyUrl() }, token).then((created) => {
+        const id = created.body._id;
+        cy.api('DELETE', `${COMPANIES}/${id}`, null, token).then((del) => {
+          expect(del.status).to.equal(204);
+        });
+        cy.api('GET', `${COMPANIES}/${id}`, null, token).then((get) => {
+          expect(get.status).to.equal(404);
+        });
+      });
+    });
+  });
+
+  describe('POST /api/v1/linkedin/contacts', () => {
+    it('US07-CY-001 | should return 201 and create a Recruiter contact', () => {
+      cy.fixture('linkedin').then((f) => {
+        const payload = { ...f.validRecruiter, linkedinUrl: uniqueContactUrl() };
+        cy.api('POST', CONTACTS, payload, token).then((res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body.type).to.equal('Recrutador');
+        });
+      });
+    });
+
+    it('US07-CY-002 | should return 201 and create a Collaborator contact', () => {
+      cy.fixture('linkedin').then((f) => {
+        const payload = { ...f.validCollaborator, linkedinUrl: uniqueContactUrl() };
+        cy.api('POST', CONTACTS, payload, token).then((res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body.type).to.equal('Colaborador');
+        });
+      });
+    });
+
+    it('US07-CY-003 | should return 409 for duplicate LinkedIn URL', () => {
+      const url = uniqueContactUrl();
+      cy.api('POST', CONTACTS, { name: 'Ana', linkedinUrl: url, type: 'Recrutador' }, token);
+      cy.api('POST', CONTACTS, { name: 'Ana2', linkedinUrl: url, type: 'Recrutador' }, token).then((res) => {
+        expect(res.status).to.equal(409);
+        expect(res.body.message).to.equal('Contato já cadastrado');
+      });
+    });
+
+    it('US07-CY-004 | should return 400 for URL not matching linkedin.com/in/ pattern', () => {
+      cy.fixture('linkedin').then((f) => {
+        cy.api('POST', CONTACTS, f.invalidContactUrl, token).then((res) => {
+          expect(res.status).to.equal(400);
+        });
+      });
+    });
+
+    it('US07-CY-005 | should return 400 for invalid contact type', () => {
+      cy.fixture('linkedin').then((f) => {
+        const payload = { ...f.invalidContactType, linkedinUrl: uniqueContactUrl() };
+        cy.api('POST', CONTACTS, payload, token).then((res) => {
+          expect(res.status).to.equal(400);
+        });
+      });
+    });
+  });
+
+  describe('GET /api/v1/linkedin/contacts', () => {
+    it('US07-CY-006 | should return all contacts for authenticated user', () => {
+      cy.api('POST', CONTACTS, { name: 'R1', linkedinUrl: uniqueContactUrl(), type: 'Recrutador' }, token);
+      cy.api('POST', CONTACTS, { name: 'C1', linkedinUrl: uniqueContactUrl(), type: 'Colaborador' }, token);
+
+      cy.api('GET', CONTACTS, null, token).then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('array').with.lengthOf(2);
+      });
+    });
+  });
+
+  describe('PUT | DELETE /api/v1/linkedin/contacts/:id', () => {
+    it('US07-CY-007 | should return 200 and updated fields for PUT', () => {
+      cy.api('POST', CONTACTS, { name: 'To Update', linkedinUrl: uniqueContactUrl(), type: 'Recrutador' }, token).then((created) => {
+        cy.api('PUT', `${CONTACTS}/${created.body._id}`, { notes: 'Reached out' }, token).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.notes).to.equal('Reached out');
+        });
+      });
+    });
+
+    it('US07-CY-008 | should return 204 for DELETE and 404 on subsequent GET', () => {
+      cy.api('POST', CONTACTS, { name: 'To Delete', linkedinUrl: uniqueContactUrl(), type: 'Colaborador' }, token).then((created) => {
+        const id = created.body._id;
+        cy.api('DELETE', `${CONTACTS}/${id}`, null, token).then((del) => {
+          expect(del.status).to.equal(204);
+        });
+        cy.api('GET', `${CONTACTS}/${id}`, null, token).then((get) => {
+          expect(get.status).to.equal(404);
+        });
+      });
+    });
+  });
+});

--- a/tests/users/users.cy.js
+++ b/tests/users/users.cy.js
@@ -1,0 +1,107 @@
+const BASE = '/api/v1';
+const uniqueEmail = () => `cy_user_${Date.now()}_${Math.random().toString(36).slice(2)}@jobapp.test`;
+
+describe('[USERS] Users Layer — Cypress', () => {
+  describe('POST /api/v1/users/register', () => {
+    it('US01-CY-001 | should return 201 and user object for valid registration', () => {
+      cy.fixture('users').then((f) => {
+        const user = { ...f.validUser, email: uniqueEmail() };
+        cy.register(user).then((res) => {
+          expect(res.status).to.equal(201);
+          expect(res.body.message).to.equal('Usuário cadastrado com sucesso');
+          expect(res.body.user).to.include.keys('_id', 'name', 'email');
+          expect(res.body.user).to.not.have.property('password');
+        });
+      });
+    });
+
+    it('US01-CY-002 | should return 409 for duplicate email', () => {
+      const email = uniqueEmail();
+      cy.register({ name: 'First', email, password: 'First1234' }).then(() => {
+        cy.register({ name: 'Dup', email, password: 'Dup12345' }).then((res) => {
+          expect(res.status).to.equal(409);
+          expect(res.body.message).to.equal('E-mail já cadastrado');
+        });
+      });
+    });
+
+    it('US01-CY-003 | should return 400 for password shorter than 8 chars', () => {
+      cy.fixture('users').then((f) => {
+        cy.register({ ...f.weakPassword, email: uniqueEmail() }).then((res) => {
+          expect(res.status).to.equal(400);
+          const msgs = res.body.errors.map((e) => e.message).join(' ');
+          expect(msgs).to.include('8');
+        });
+      });
+    });
+
+    it('US01-CY-004 | should return 400 for password without numbers', () => {
+      cy.fixture('users').then((f) => {
+        cy.register({ ...f.noNumberPassword, email: uniqueEmail() }).then((res) => {
+          expect(res.status).to.equal(400);
+          const msgs = res.body.errors.map((e) => e.message).join(' ');
+          expect(msgs).to.include('número');
+        });
+      });
+    });
+
+    it('US01-CY-005 | should return 400 for invalid email format', () => {
+      cy.fixture('users').then((f) => {
+        cy.register(f.invalidEmail).then((res) => {
+          expect(res.status).to.equal(400);
+          const fields = res.body.errors.map((e) => e.field);
+          expect(fields).to.include('email');
+        });
+      });
+    });
+
+    it('US01-CY-006 | should return 400 when name field is missing', () => {
+      cy.register({ email: uniqueEmail(), password: 'NoName123' }).then((res) => {
+        expect(res.status).to.equal(400);
+        const fields = res.body.errors.map((e) => e.field);
+        expect(fields).to.include('name');
+      });
+    });
+
+    it('US01-CY-007 | should return 400 when all required fields are missing', () => {
+      cy.register({}).then((res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body.errors.length).to.be.greaterThan(1);
+      });
+    });
+  });
+
+  describe('GET /api/v1/users/me', () => {
+    it('US01-CY-008 | should return 200 with user profile for authenticated user', () => {
+      cy.registerAndLogin().then(({ token, userId }) => {
+        cy.api('GET', `${BASE}/users/me`, null, token).then((res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.user._id).to.equal(userId);
+          expect(res.body.user).to.not.have.property('password');
+        });
+      });
+    });
+
+    it('US01-CY-009 | should return 401 without token', () => {
+      cy.request({
+        method: 'GET',
+        url: `${BASE}/users/me`,
+        failOnStatusCode: false,
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+      });
+    });
+
+    it('US01-CY-010 | should return 401 for malformed token', () => {
+      cy.request({
+        method: 'GET',
+        url: `${BASE}/users/me`,
+        failOnStatusCode: false,
+        headers: { Authorization: 'Bearer this.is.garbage' },
+      }).then((res) => {
+        expect(res.status).to.equal(401);
+        expect(res.body.message).to.equal('Token inválido');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Pipeline de testes E2E com Cypress em modo headless, disparada automaticamente em todo Pull Request apontando para `main`.

## Fluxo da pipeline

```
pull_request → main
      │
      └─► cypress (ubuntu-latest / Node 20)
            │
            ├── 1. Checkout do repositório
            ├── 2. Setup Node 20
            ├── 3. npm ci          ← instala dependências
            ├── 4. node server.js & ← app em background
            ├── 5. wait /health    ← aguarda servidor (até 60s)
            ├── 6. cypress run --headless --browser electron
            ├── 7. upload screenshots (só em falha)
            └── 8. pkill node      ← finaliza servidor
```

## Suites de teste (49 specs Cypress)

| Suite | Specs | User Stories |
|-------|-------|--------------|
| Auth | 10 | US02 — JWT Authentication |
| Users | 10 | US01 — User Registration |
| Job Applications | 13 | US03/US05 — CRUD + Stage Tracking |
| LinkedIn | 16 | US06/US07 — Companies + Contacts |

## Arquivos criados

- `.github/workflows/cypress-ci.yml` — workflow
- `cypress.config.js` — configuração (headless, electron, specPattern)
- `cypress/support/commands.js` — custom commands reutilizáveis
- `cypress/support/e2e.js` — support file
- `tests/*/‌*.cy.js` — 4 suites de specs
- `tests/fixtures/*.json` — dados de teste

## Secrets necessários (já configurados no repositório)
- `MONGODB_URI`
- `JWT_SECRET`
- `JWT_REFRESH_SECRET`

## Test plan
- [ ] Abrir este PR → verificar job `cypress` disparado na aba Actions
- [ ] Job conclui com ✅ — 49 testes passando
- [ ] Em caso de falha: screenshots disponíveis como artefato

🤖 Generated with [Claude Code](https://claude.com/claude-code)